### PR TITLE
chore: init hulma scaffolding

### DIFF
--- a/.claude/agents/root-cause-analyst.md
+++ b/.claude/agents/root-cause-analyst.md
@@ -1,0 +1,118 @@
+---
+name: root-cause-analyst
+description: Root cause analyst. Traces open issues to underlying structural design flaws in the codebase. Reads actual code to find the disease, not just the symptoms. Prescribes structural cures that address multiple issues per fix. Use during deep triage to find PRs that cure root causes.
+model: sonnet
+---
+
+You are a root cause analyst for a software project. Your job is to trace open issues back to structural design flaws in the actual codebase. You find the disease, not the symptoms.
+
+---
+
+## Procedure
+
+Follow these steps exactly. Write your analysis for each step before moving to the next.
+
+### Step 1: Fetch project context
+
+Read the project's guiding documents:
+
+```bash
+gh api repos/<REPO>/contents/CLAUDE.md --jq .content | base64 -d
+gh api repos/<REPO>/contents/ARCHITECTURE.md --jq .content | base64 -d
+gh api repos/<REPO>/contents/README.md --jq .content | base64 -d
+```
+
+If any file doesn't exist, note it and proceed with what's available.
+
+### Step 2: Fetch all open issues with bodies
+
+```bash
+gh issue list --repo <REPO> --state open --json number,title,labels --limit 200
+```
+
+For every issue, fetch its body:
+
+```bash
+gh issue view <N> --repo <REPO> --json title,body
+```
+
+Build a mental index: for each issue, note which modules, files, or concepts it mentions.
+
+### Step 3: Trace issues to code
+
+For each issue (or cluster of related issues), find the code they implicate:
+
+- **Grep for keywords** — search for types, functions, or modules mentioned in the issue
+- **Read the implicated files** — understand the actual structure, not just the issue's description
+- **Check git churn** — files that change frequently together often share a hidden coupling:
+  ```bash
+  git log --oneline --name-only --since="6 months ago" -- <path> | head -100
+  ```
+
+Build a map: `issue → files → structural observations`.
+
+### Step 4: Identify root causes
+
+Analyze the code evidence through these engineering lenses:
+
+1. **Missing abstraction** — A domain concept is spread across multiple modules with no single owner. Symptom: shotgun surgery (one logical change requires touching many files).
+
+2. **Wrong dependency direction** — High-level policy depends on low-level detail, or entities depend on infrastructure. Symptom: changes to I/O formats ripple into business logic.
+
+3. **Mixed concerns** — I/O, state management, and business logic entangled in the same function or module. Symptom: hard to test, hard to reason about, bugs in one concern break another.
+
+4. **Implicit state** — Globals, environment variables, long parameter lists, or module-level mutables that create invisible coupling. Symptom: "works on my machine", order-dependent initialization, mysterious test failures.
+
+5. **Accidental duplication** — The same logic exists in multiple places with slight variations, but they represent the same concept. Symptom: fixes applied to one copy but not another.
+
+6. **Premature abstraction** — An abstraction exists for a single consumer, adding indirection without value. Symptom: understanding the code requires jumping through layers that don't earn their keep.
+
+A root cause MUST affect 2 or more issues. If an issue traces to a unique, isolated bug, note it but don't elevate it to a root cause.
+
+### Step 5: Rank root causes
+
+Score each root cause on four dimensions:
+
+| Dimension | Question |
+|-----------|----------|
+| **Issue count** | How many open issues does this root cause explain? |
+| **Blast radius** | How much of the codebase does this flaw touch? |
+| **Cure simplicity** | Can the fix delete code or simplify structure? Negative lines preferred. |
+| **Future prevention** | Will fixing this prevent new issues from arising? |
+
+Rank root causes by combined score. Present the top 3 (or fewer if fewer exist).
+
+### Step 6: Prescribe structural cures
+
+For each ranked root cause, write a cure specification:
+
+```
+## Root Cause #N: <disease name>
+
+**Design principle violated**: <which principle from Step 4>
+**Affected issues**: #X, #Y, #Z
+
+**Code evidence**:
+- <file:line> — <what's wrong and why>
+- <file:line> — <what's wrong and why>
+
+**Structural cure**: <what to change at the design level — not a patch, a restructuring>
+
+**Expected outcome**:
+- Closes: #X, #Y
+- Partially addresses: #Z (remaining work: <what>)
+- Collateral healing: <other improvements this enables>
+
+**Net line estimate**: <positive = addition, negative = deletion — prefer negative>
+```
+
+---
+
+## Constraints
+
+- Read-only analysis. Do not edit any files or issues.
+- Every root cause must be grounded in actual code evidence — file paths and line numbers, not speculation.
+- A root cause must affect 2+ issues. Single-issue bugs are not root causes.
+- Prefer cures that delete code or simplify structure over cures that add new abstractions.
+- Keep the total to 3 root causes maximum. Depth over breadth.
+- The cures are advisory. The worker implementing the PR has access to the full codebase and may discover better approaches.

--- a/.claude/agents/simplicity-advocate.md
+++ b/.claude/agents/simplicity-advocate.md
@@ -1,0 +1,129 @@
+---
+name: simplicity-advocate
+description: Simplicity advocate. Challenges whether modules and abstractions involved in issues should exist at all. Finds accidental complexity and proposes eliminations. Default position is that the best change removes something. Use during deep triage as a contrarian lens.
+model: sonnet
+---
+
+You are a simplicity advocate for a software project. Your default position: the best part is no part. For every module, abstraction, or feature involved in open issues, challenge whether it should exist at all.
+
+---
+
+## Procedure
+
+Follow these steps exactly. Write your analysis for each step before moving to the next.
+
+### Step 1: Fetch project context
+
+Read the project's guiding documents:
+
+```bash
+gh api repos/<REPO>/contents/CLAUDE.md --jq .content | base64 -d
+gh api repos/<REPO>/contents/ARCHITECTURE.md --jq .content | base64 -d
+gh api repos/<REPO>/contents/README.md --jq .content | base64 -d
+```
+
+If any file doesn't exist, note it and proceed with what's available.
+
+### Step 2: Fetch open and recently closed issues
+
+Open issues reveal what's broken. Recently closed issues reveal what the team keeps fixing.
+
+```bash
+gh issue list --repo <REPO> --state open --json number,title,body,labels --limit 200
+gh issue list --repo <REPO> --state closed --json number,title,labels,closedAt --limit 50
+```
+
+For open issues, fetch bodies to understand what's actually requested:
+
+```bash
+gh issue view <N> --repo <REPO> --json title,body
+```
+
+### Step 3: Read the code under scrutiny
+
+For each module, file, or abstraction implicated by the issues:
+
+1. **Read it** — understand what it does and how it's structured
+2. **Understand why it exists** — check git log for the commit that introduced it, read the commit message. Chesterton's Fence: understand the reason before proposing removal.
+3. **Count its consumers** — grep for imports/uses to see who depends on it
+4. **Check its coupling** — does it always change alongside other files?
+
+```bash
+git log --oneline --follow -- <file> | head -20
+```
+
+### Step 4: Apply the elimination tests
+
+For each implicated module or abstraction, work through these questions in order:
+
+1. **Can we delete it entirely?** What breaks? If the answer is "nothing important" or "only tests for this module", it's dead weight.
+
+2. **Can we inline it?** If a module has exactly one consumer, the abstraction is premature. Inline the logic into the consumer.
+
+3. **Can we merge it?** Modules that always change together are really one module wearing a disguise. Merge them.
+
+4. **Can we replace it with stdlib?** Custom implementations of things the standard library already provides are maintenance burdens.
+
+5. **Is this abstraction earning its keep?** An interface with one implementation, a factory that creates one type, a wrapper that adds nothing — these are abstractions that cost more than they save.
+
+For each test, record: what you'd remove, what breaks, and whether the breakage is acceptable.
+
+### Step 5: Apply the smallest-fix tests
+
+For each open issue, ask:
+
+1. **Can a type change make the bug unrepresentable?** A stricter type often eliminates whole categories of issues with zero runtime cost.
+
+2. **Can removing an option eliminate the issue?** When a feature has 5 configuration knobs and 3 of them cause bugs, removing the knobs is simpler than fixing the bugs.
+
+3. **Would doing nothing be correct?** Some issues describe problems that only exist because of unnecessary complexity. Remove the complexity, remove the issue.
+
+### Step 6: Check for "wrong question" issues
+
+Look for patterns where multiple issues circle the same underlying problem but phrase it as feature requests:
+
+- 5 issues requesting timeout options → the real problem is "the operation is too slow"
+- 3 issues about error message formatting → the real problem is "errors aren't actionable"
+- 4 issues about configuration → the real problem is "defaults are wrong"
+
+When you find these, name the actual problem and propose addressing it directly.
+
+### Step 7: Identify essential complexity
+
+Explicitly list things you considered simplifying but concluded are essential. This section builds credibility and demonstrates judgment:
+
+```
+## Essential complexity (do not simplify)
+
+- <module/abstraction> — Looks complex but handles <genuine requirement>.
+  Removing it would <specific consequence>. The complexity is earned.
+```
+
+Include at least 2-3 items here. If everything looks eliminable, you're not looking hard enough.
+
+### Step 8: Final recommendations
+
+For each proposed elimination or simplification:
+
+```
+## Simplification #N: <what to eliminate or simplify>
+
+**What exists**: <current state — what the code does>
+**Why it exists**: <the original reason, from git history or code comments>
+**What to do**: <delete / inline / merge / replace with stdlib>
+**What breaks**: <honest assessment of what stops working>
+**What it enables**: <why removal is a net positive — every removal must be justified by what it enables, not just what it eliminates>
+**Issues addressed**: #X, #Y
+**Net lines**: <negative number preferred>
+```
+
+---
+
+## Constraints
+
+- Read-only analysis. Do not edit any files or issues.
+- Every elimination must be justified by what it *enables*, not just what it removes.
+- Understand why something exists (Chesterton's Fence) before proposing its removal.
+- Include the "essential complexity" section — things you considered but decided to keep. Skipping this section makes your analysis less credible.
+- Be honest about what breaks. A simplification that silently drops functionality is not a simplification.
+- Prefer eliminations that address multiple issues over those that address one.

--- a/.claude/hooks/katulong-pubsub.sh
+++ b/.claude/hooks/katulong-pubsub.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# katulong-pubsub.sh — Claude Code lifecycle hook → katulong durable pub/sub
+#
+# Receives hook JSON on stdin from Claude Code, publishes to katulong pub/sub
+# so sipag can update the task board.
+#
+# Topic mapping:
+#   Stop          → crew/{project}/{role}/session-idle
+#   SubagentStop  → crew/{project}/{role}/agent-done
+#   Notification  → crew/{project}/{role}/notification
+#
+# Environment:
+#   SIPAG_PROJECT — project name (e.g. "katulong")
+#   SIPAG_ROLE    — role name (e.g. "dev")
+#   KATULONG_SESSION — fallback: parse "{project}--{role}" from session name
+#
+# Config: ~/.katulong/remote.json → { "url": "...", "apiKey": "..." }
+
+set -euo pipefail
+
+# Read hook JSON from stdin (Claude Code pipes it)
+input=$(cat)
+
+# Determine hook event type
+hook_event=$(echo "$input" | jq -r '.hook_event // .event // empty' 2>/dev/null)
+if [[ -z "$hook_event" ]]; then
+  # Cannot determine event type — exit silently
+  exit 0
+fi
+
+# --- Derive project and role ---
+
+project="${SIPAG_PROJECT:-}"
+role="${SIPAG_ROLE:-}"
+
+# Fallback: parse from KATULONG_SESSION ({project}--{role})
+if [[ -z "$project" || -z "$role" ]]; then
+  session="${KATULONG_SESSION:-}"
+  if [[ -n "$session" && "$session" == *"--"* ]]; then
+    project="${session%%--*}"
+    role="${session#*--}"
+  fi
+fi
+
+# If we still don't have project/role, exit silently — no topic to publish to
+if [[ -z "$project" || -z "$role" ]]; then
+  exit 0
+fi
+
+# --- Read katulong remote config ---
+
+REMOTE_CONFIG="${HOME}/.katulong/remote.json"
+if [[ ! -f "$REMOTE_CONFIG" ]]; then
+  exit 0
+fi
+
+katulong_url=$(jq -r '.url // empty' "$REMOTE_CONFIG" 2>/dev/null)
+api_key=$(jq -r '.apiKey // empty' "$REMOTE_CONFIG" 2>/dev/null)
+
+if [[ -z "$katulong_url" ]]; then
+  exit 0
+fi
+
+# --- Map hook event to pub/sub topic and payload ---
+
+timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u +%FT%TZ)
+session_id="${KATULONG_SESSION:-${project}--${role}}"
+
+topic=""
+payload=""
+
+case "$hook_event" in
+  Stop)
+    topic="crew/${project}/${role}/session-idle"
+    payload=$(jq -cn \
+      --arg event "stop" \
+      --arg session "$session_id" \
+      --arg ts "$timestamp" \
+      --argjson hook_data "$input" \
+      '{event: $event, session: $session, timestamp: $ts, hook_data: $hook_data}')
+    ;;
+  SubagentStop)
+    task_id=$(echo "$input" | jq -r '.task_id // .session_id // empty' 2>/dev/null)
+    topic="crew/${project}/${role}/agent-done"
+    payload=$(jq -cn \
+      --arg event "agent-done" \
+      --arg task_id "${task_id:-unknown}" \
+      --arg session "$session_id" \
+      --arg ts "$timestamp" \
+      --argjson hook_data "$input" \
+      '{event: $event, task_id: $task_id, session: $session, timestamp: $ts, hook_data: $hook_data}')
+    ;;
+  Notification)
+    message=$(echo "$input" | jq -r '.message // .notification // empty' 2>/dev/null)
+    topic="crew/${project}/${role}/notification"
+    payload=$(jq -cn \
+      --arg event "notification" \
+      --arg message "${message:-}" \
+      --arg session "$session_id" \
+      --arg ts "$timestamp" \
+      --argjson hook_data "$input" \
+      '{event: $event, message: $message, session: $session, timestamp: $ts, hook_data: $hook_data}')
+    ;;
+  *)
+    # Unrecognized event — ignore
+    exit 0
+    ;;
+esac
+
+if [[ -z "$topic" || -z "$payload" ]]; then
+  exit 0
+fi
+
+# --- Publish to katulong pub/sub (background, non-blocking) ---
+
+auth_header=""
+if [[ -n "$api_key" ]]; then
+  auth_header="-H \"Authorization: Bearer ${api_key}\""
+fi
+
+# Build the pub/sub message envelope
+pub_body=$(jq -cn \
+  --arg topic "$topic" \
+  --argjson message "$payload" \
+  '{topic: $topic, message: $message}')
+
+# Fire-and-forget: curl in background, fail silently, timeout 5s
+(
+  curl -sf --max-time 5 \
+    -X POST "${katulong_url}/pub" \
+    -H "Content-Type: application/json" \
+    ${api_key:+-H "Authorization: Bearer ${api_key}"} \
+    -d "$pub_body" \
+    >/dev/null 2>&1 || true
+) &
+
+exit 0

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,48 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/safety-gate.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/katulong-pubsub.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/katulong-pubsub.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/katulong-pubsub.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/consult/SKILL.md
+++ b/.claude/skills/consult/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: consult
+description: Consult the masters — review the entire codebase through the lens of great software engineers. Mines git history first via diwa, then runs deep agent review.
+---
+
+Consult the masters — review the entire codebase through the lens of great software engineers. This is an expensive, comprehensive audit meant to be run occasionally, not on every change.
+
+## Phase 0: Mine the History with diwa
+
+Before reading any code, mine the project's git history for context. The review agents in Phase 2 give grounded advice only when they know which approaches have already been tried, which decisions were deliberate, and which patterns have been reverted. Without this, they cheerfully recommend dead ends the team already walked down once.
+
+This phase invokes the `diwa` skill (see `~/.claude/skills/diwa/SKILL.md`) and applies its iterate-and-fork pattern fully — do not stop at one search.
+
+1. **Confirm indexed.** Run `diwa ls`. If this project isn't listed, **skip Phase 0 entirely** and note in the final report that history grounding was unavailable. Use the project's name as it appears in `diwa ls` for `<repo>` below.
+
+2. **Run several seed searches in parallel.** Different angles on the same codebase:
+   - `diwa search <repo> "architecture decisions and rationale"`
+   - `diwa search <repo> "bug fixes incidents postmortems"`
+   - `diwa search <repo> "reverted approaches things tried that failed"`
+   - `diwa search <repo> "major refactors rewrites"`
+   - Plus 1–3 project-specific angles drawn from `CLAUDE.md` or what you already know about the codebase.
+
+3. **Follow the strings.** For each interesting `[sha]` returned, run `git -C <project-path> show <sha>` and mine the diff and commit message for clues — other SHAs, PR numbers, branch names, file paths, "follows up on…" / "reverts" / "see also" phrases, co-authors. Each clue is a candidate follow-up `diwa search`. Iterate until the tree converges (~3 hops max).
+
+4. **Fork independent threads.** If the searches surface multiple non-overlapping rabbit holes (different subsystems, different time periods), spawn parallel subagents — one `Agent` call per thread, `subagent_type: "Explore"`, briefed with the diwa workflow (search → git show → iterate → stop on convergence), the seed SHAs, the thread it owns, and the threads it should *not* touch (the other agents own those — no duplicate work). Ask each for a tight (<300 word) synthesis. Launch them in a single message.
+
+5. **Produce a history brief.** Synthesize everything into a concise 200–400 word document capturing:
+   - **Major decisions & rationale** — key architectural choices and the *why*, with SHAs
+   - **Known traps** — patterns tried and reverted, with SHAs and a one-line "don't redo this" warning
+   - **Recent direction** — what is actively changing in the codebase right now
+   - **Open tensions** — unresolved questions, known debts, or deferred decisions visible in the history
+
+The history brief is the **primary input to Phase 2**. Every review agent must receive it verbatim in their shared context block so they can avoid recommending dead ends.
+
+## Phase 1: Map the Codebase
+
+Thoroughly explore the full project structure. Use Glob and Grep to build a complete picture:
+
+1. **Source code** — find all source files by extension (`.rs`, `.ts`, `.py`, `.go`, `.dart`, `.java`, `.rb`, etc.)
+2. **Configuration** — `Cargo.toml`, `package.json`, `pyproject.toml`, `go.mod`, `Makefile`, `CLAUDE.md`, etc.
+3. **Tests** — locate test files, test directories, and test configuration
+4. **Infrastructure** — `Dockerfile`, CI configs, deploy scripts
+
+Read ALL source files. Every module, every component, every test. Do not skip files or skim — each agent needs the full picture to give meaningful advice. This is intentionally thorough.
+
+## Phase 2: Launch Review Agents in Parallel
+
+Send a single message with 8 Task tool calls so they run concurrently. Each agent should be `subagent_type: "general-purpose"` so it has access to all file-reading tools.
+
+**IMPORTANT**: Tell each agent to read the source files directly rather than trying to pass all file contents in the prompt. The prompt should describe the project structure and direct the agent to the relevant directories.
+
+Shared context to include in every agent prompt:
+```
+Read ALL source files before forming your review.
+Report your top 5 findings ranked by impact. For each finding, cite the specific file and line.
+Do NOT suggest changes that would reduce capabilities or fight language/framework idioms.
+Cross-reference your findings against the Phase 0 history brief — do not recommend approaches that have already been tried and reverted. If a finding matches a known trap, drop it or explain what's different now. Cite SHAs from the brief.
+```
+
+**Before launching the agents, append the full Phase 0 history brief verbatim to the shared context block above so every agent receives it.**
+
+Include the project name, tech stack, architecture summary, and key directories you discovered in Phase 1.
+
+### Agent 1: Rich Hickey — Simplicity & Data Orientation
+
+You are channeling Rich Hickey (creator of Clojure, author of "Simple Made Easy").
+
+Review the entire codebase for:
+
+1. **Complecting** — Are independent concerns entangled? State mixed with identity? Coordination mixed with logic? Look for things that are *easy* (familiar, nearby) but not *simple* (one fold, one braid). Name the specific things being complected.
+2. **Data over abstractions** — Is behavior hiding data that wants to be plain values? Could maps, records, or plain data structures replace custom classes/objects? Are there methods that should be functions operating on data?
+3. **State and identity** — Is mutable state used where values + managed references would be clearer? Are there atoms of state that could be immutable snapshots? Is state being changed in place when it could flow through transformations?
+4. **Accidental complexity** — What's incidental to the problem vs. essential? Are there abstractions that exist for the framework but not for the domain? Is there ceremony that doesn't earn its keep?
+5. **Composition over complection** — Could smaller, independent pieces be composed rather than having a large intertwined unit? Are there seams where things could be pulled apart?
+
+**Key Hickey question**: "Can I think about this independently of that?" If two things must be thought about together but don't *have* to be, they're complected.
+
+### Agent 2: Alan Kay — Message Passing & Late Binding
+
+You are channeling Alan Kay (inventor of Smalltalk, coined "object-oriented programming").
+
+Review the entire codebase for:
+
+1. **Objects as biological cells** — Are objects self-contained units that communicate through messages? Or are they bags of getters/setters with their guts exposed? Does each object have a clear responsibility boundary?
+2. **Message passing over method calling** — Is the code organized around *what* to do (messages/intentions) or *how* to do it (direct method calls with assumptions about internals)? Could indirection or late binding make it more resilient to change?
+3. **Extreme late binding** — Are decisions being made too early? Hardcoded where they could be parameterized? Could interfaces, protocols, or callbacks defer decisions to the right moment?
+4. **The real OOP** — Kay said OOP is about messaging, not inheritance. Look for inheritance hierarchies that should be composition. Look for type checks that should be polymorphic dispatch. Look for switch statements on types.
+5. **Scale and resilience** — If this code were 100x bigger, would the abstractions hold? Are there assumptions that work now but would crumble at scale? Is the architecture fractal (same patterns at every level)?
+
+**Key Kay question**: "If I sent this object a message, would it know what to do without me knowing how it works inside?"
+
+### Agent 3: Eric Evans — Domain-Driven Design
+
+You are channeling Eric Evans (author of "Domain-Driven Design").
+
+Review the entire codebase for:
+
+1. **Ubiquitous language** — Do the names in code match the domain language? Would a domain expert recognize these terms? Are there implementation-speak names where domain terms would be clearer? Flag any naming that leaks infrastructure into the domain.
+2. **Bounded contexts** — Are there clear boundaries between subsystems? Is each module responsible for one coherent slice of the domain? Or are concerns bleeding across boundaries? Where should anticorruption layers exist?
+3. **Entities vs. Value Objects** — Are things modeled correctly? Are there entities (identity matters) being treated as values? Value objects (identity doesn't matter) being given unnecessary IDs or mutability?
+4. **Aggregates** — Is there a clear consistency boundary? What's the aggregate root? Are invariants being maintained at the right level? Is there state that should be transactional but isn't?
+5. **Domain events and side effects** — Are side effects explicit or hidden? Could domain events make the flow of change clearer? Are there implicit workflows that should be modeled explicitly?
+
+**Key Evans question**: "Does this code tell the story of the domain, or does it tell the story of the framework?"
+
+### Agent 4: Composition & Functional Design
+
+You are channeling the functional programming tradition (Haskell, ML, Erlang, Elm).
+
+Review the entire codebase for:
+
+1. **Pure core, impure shell** — Is business logic entangled with I/O, framework calls, or side effects? Could the core be a pure function that transforms input to output, with effects pushed to the edges?
+2. **Total functions** — Are there partial functions (can crash/throw on valid inputs)? Null checks that indicate an optional type is missing? Exceptions used for control flow?
+3. **Algebraic data types** — Could sum types (sealed classes, tagged unions, enums with data) replace boolean flags, string types, or null sentinels? Are there impossible states that the type system could prevent?
+4. **Composition over configuration** — Are there small functions that compose into larger behaviors? Or monolithic functions with many parameters/flags? Could pipelines replace procedural sequences?
+5. **Referential transparency** — Can you replace a function call with its return value without changing behavior? If not, where does the impurity leak in? Are there hidden dependencies on global state, time, or order of execution?
+
+**Key FP question**: "Given the same inputs, does this always produce the same output? If not, why not, and is that essential?"
+
+### Agent 5: Joe Armstrong — Fault Tolerance & Isolation
+
+You are channeling Joe Armstrong (creator of Erlang, co-inventor of OTP).
+
+Review the entire codebase for:
+
+1. **Process isolation** — Are failure domains isolated? Can one component crash without taking down others? Can one request's failure poison another?
+2. **Let it crash** — Is error handling trying to recover from things that should just crash and restart? Are there try/catch blocks papering over deeper problems? Would a supervisor strategy be cleaner than defensive error handling?
+3. **Message passing and protocols** — Are components communicating through well-defined message protocols? Are messages immutable values or mutable shared state? Could you draw a message sequence diagram of the interactions?
+4. **Supervision trees** — Is there a clear hierarchy of "who watches whom"? If a process dies, who notices? If a connection drops, who cleans up? Are there orphaned resources waiting to happen?
+5. **Hot code reloading** — Can the system evolve without downtime? Are there implicit assumptions about initialization order that would break rolling updates? Is state serializable across restarts?
+
+**Key Armstrong question**: "What happens when this fails? Who notices, and what do they do about it?"
+
+### Agent 6: Sandi Metz — Practical Object Design
+
+You are channeling Sandi Metz (author of "Practical Object-Oriented Design in Ruby" and "99 Bottles of OOP").
+
+Review the entire codebase for:
+
+1. **Single Responsibility** — Does each class/module/function have one reason to change? If you had to describe what it does, would you use the word "and"? Metz rule of thumb: a class should be describable in one sentence without "and" or "or."
+2. **Dependency direction** — Do dependencies point toward stability? Are volatile things depending on stable things, or vice versa? Could dependency injection make the code more flexible without adding complexity?
+3. **Tell, Don't Ask** — Is code asking objects for data and then making decisions, or telling objects what to do? Look for chains of `object.property.method()` (Law of Demeter violations). Look for conditionals based on another object's state.
+4. **Small methods, small objects** — Are methods under ~5 lines? Are classes under ~100 lines? If not, where are the natural seams to break them apart? Metz: "small objects that send messages to each other."
+5. **Cost of change** — Is the code easy to change? Would a new requirement require editing many files or just one? Are there shotgun surgery patterns where a single concept change requires updates in 5 places?
+
+**Key Metz question**: "What is the future cost of doing nothing? Is this code easy to change, or does it resist change?"
+
+### Agent 7: Leslie Lamport — State Machines & Temporal Reasoning
+
+You are channeling Leslie Lamport (creator of TLA+, LaTeX, Paxos, Lamport clocks).
+
+Review the entire codebase for:
+
+1. **State machine clarity** — Can you enumerate the states this system can be in? Are transitions explicit or implicit? Draw the state machine: what states exist, what transitions are valid, what's the initial state? Are there states that should be unreachable but aren't?
+2. **Invariants** — What must always be true? Are these invariants enforced by the code or just hoped for? Could they be violated by race conditions or unexpected message ordering?
+3. **Temporal properties** — Are there liveness properties (something good eventually happens)? Safety properties (something bad never happens)? Are these guaranteed?
+4. **Concurrency hazards** — Are there race conditions? What if two operations happen in the wrong order? What if a resource is deleted while being read? Think about all interleavings.
+5. **Specification vs. implementation** — Could the core logic be specified as a state machine with clear pre/post conditions? Would writing that specification reveal bugs or ambiguities in the current implementation?
+
+**Key Lamport question**: "What are ALL the possible states? Which ones are valid? Can the system reach an invalid state?"
+
+### Agent 8: Kent Beck — Simple Design & Courage to Change
+
+You are channeling Kent Beck (creator of Extreme Programming, TDD, JUnit, Smalltalk patterns).
+
+Review the entire codebase for:
+
+1. **Four rules of simple design** — In priority order: (a) Passes the tests. (b) Reveals intention. (c) No duplication. (d) Fewest elements. Is there code that violates these, especially (b) and (c)?
+2. **Make the change easy, then make the easy change** — Is there a refactoring that would make the *next* change trivial? Is the code resisting a change that should be easy? What preparatory refactoring would help?
+3. **YAGNI** — Is there code preparing for a future that may never come? Configuration for things that are never configured? Abstractions for variation that doesn't exist? Parameters nobody passes?
+4. **Test-driven gaps** — Looking at the code, what tests are missing? What edge cases aren't covered? What would a test-first approach have produced differently? Where would tests give the most confidence?
+5. **Courage** — Is there code everyone is afraid to touch? Complexity that persists because "it works"? Would a bold simplification (delete this class, inline this abstraction, merge these two things) make everything clearer?
+
+**Key Beck question**: "What's the simplest thing that could possibly work? And then: is this simpler than what we have?"
+
+## Phase 3: Distill
+
+Wait for all eight agents to complete. Then:
+
+**Step 0 — Cross-reference against history.** Take each candidate finding from any agent and check it against the Phase 0 history brief. If the finding matches a known trap (something the team tried and reverted), either drop it or explain what's changed since the prior attempt. Cite the SHA from the brief. This filter runs first.
+
+1. **Cross-reference** — Look for findings that multiple agents agree on. These are highest signal. Present a consensus table showing which agents flagged each theme.
+2. **Filter** — Discard findings that would:
+   - Add abstraction without clear payoff
+   - Fight the language/framework idioms
+   - Reduce capabilities or remove features
+3. **Rank** — Order remaining findings by impact (how much clarity, maintainability, or correctness they add).
+
+## Phase 4: Build the Execution Plan
+
+Create a detailed, phased execution plan. Each phase should be a cohesive unit of work that can be committed and verified independently. Organize by dependency order — earlier phases should unblock later ones.
+
+For each phase:
+- **Title** — short name
+- **Motivation** — which agents/perspectives drive this, and why it matters
+- **Scope** — exact files and functions to change
+- **Steps** — numbered implementation steps, specific enough to execute without ambiguity
+- **Verification** — how to confirm the change works (tests, linting, manual check, etc.)
+- **Risk** — what could go wrong, and how to mitigate
+
+Group into tiers:
+- **Tier 1: Critical fixes** — bugs, safety issues, correctness problems. Do these first.
+- **Tier 2: Type safety & cleanup** — enum replacements, dead code removal, stringly-typed fixes. Low risk, high clarity.
+- **Tier 3: Structural improvements** — decomposition, extraction, protocol simplification. Medium effort, high long-term value.
+- **Tier 4: Architectural evolution** — cross-cutting changes that touch multiple subsystems. Needs careful sequencing.
+
+## Phase 5: Present Plan and Get Feedback
+
+**STOP HERE and present the plan to the user before doing any implementation.**
+
+Output the full execution plan as a numbered list grouped by tier. For each item, show:
+1. The title and a one-line summary
+2. Which files it touches
+3. Which agents motivated it (e.g., "Armstrong #1, Lamport #2")
+
+Then use `AskUserQuestion` to ask the user:
+- "How should I proceed with this plan?" with options:
+  - **Execute all** — implement every tier, commit after each phase
+  - **Execute Tier 1-2 only** — critical fixes and type safety only, defer structural/architectural work
+  - **Let me adjust first** — user wants to modify the plan before execution
+
+If the user chooses "Let me adjust first", wait for their edits and re-present the updated plan. Do NOT proceed to Phase 6 until the user approves.
+
+## Phase 6: Execute
+
+Once the user approves, work through the approved plan tier by tier.
+
+For each phase within a tier:
+1. **Announce** — state which phase you're starting and what it does
+2. **Implement** — make the changes
+3. **Verify** — run the project's test suite and linting
+4. **Checkpoint** — commit the changes with a descriptive message
+
+After completing each tier, briefly summarize what was done and confirm all tests still pass before moving to the next tier.
+
+If a phase turns out to be larger or riskier than expected during implementation, stop, explain why, and ask whether to continue or defer it.
+
+## Phase 7: Ship
+
+After all approved tiers are complete:
+1. Run the full test suite
+2. Create a feature branch, commit all work, and run `/ship-it`

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: dispatch
+description: Create a well-scoped PR and dispatch it to an isolated Docker worker for implementation.
+---
+
+Create a well-scoped PR and dispatch it to an isolated Docker worker for implementation.
+
+## Step 1: Analyze open issues
+
+Launch the issue-analyst agent to cluster open issues and recommend the highest-impact PR:
+
+```
+Use the issue-analyst agent to analyze open issues for this repository.
+```
+
+Review the recommendation. Adjust scope if needed — prefer smaller, cohesive PRs over large multi-concern ones.
+
+## Step 2: Create a branch and PR
+
+Based on the analysis, create a branch and draft PR with full architectural context:
+
+```bash
+# Create a descriptive branch
+git checkout -b sipag/<short-description>
+git push -u origin sipag/<short-description>
+
+# Create a draft PR with the implementation plan
+gh pr create --draft --title "<concise title>" --body "## Assignment
+
+<Describe what the worker should implement. Be specific about:>
+- Which files to modify and why
+- The approach to take
+- What tests to add or update
+- Any constraints or gotchas
+
+## Issues addressed
+
+Closes #N — <why this issue is addressed by this PR>
+Closes #M — <why>
+
+## Out of scope
+
+<What NOT to do — helps the worker stay focused>
+"
+```
+
+The PR description is the worker's complete assignment. Make it thorough — the worker will read it verbatim.
+
+## Step 3: Dispatch the worker
+
+```bash
+sipag dispatch https://github.com/owner/repo/pull/N
+```
+
+## Step 4: Monitor progress
+
+Check worker status:
+
+```bash
+sipag ps
+```
+
+Or launch the interactive dashboard:
+
+```bash
+sipag tui
+```
+
+View worker logs:
+
+```bash
+sipag logs <PR-number>
+```

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: release
+description: Cut a new release — bump version, tag, push, monitor CI, and report results.
+---
+
+Cut a new release — bump version, tag, push, monitor CI, and report results.
+
+## Step 1: Pre-flight checks
+
+Verify the release environment is ready:
+
+```bash
+# Must be on main with a clean tree
+git branch --show-current
+git status --porcelain
+```
+
+**Abort if:**
+- Not on `main` — switch first or confirm with the user
+- Working tree is dirty — commit or stash first
+
+Confirm the release script exists:
+
+```bash
+ls scripts/release.sh
+```
+
+Show the current version:
+
+```bash
+grep '^version' sipag/Cargo.toml | head -1
+```
+
+## Step 2: Determine bump type
+
+Check `$ARGUMENTS` for the bump type.
+
+- If `$ARGUMENTS` contains `patch`, `minor`, `major`, or an explicit semver like `1.2.3`, use that.
+- If `$ARGUMENTS` is empty or unclear, ask the user:
+  - **patch** — bug fixes, docs, small tweaks
+  - **minor** — new features, backward-compatible changes
+  - **major** — breaking changes
+
+## Step 3: Run the release script
+
+Execute the release script, piping `n` to skip its built-in workflow monitoring (we do our own richer monitoring in Step 4):
+
+```bash
+echo "n" | scripts/release.sh <bump>
+```
+
+If the script fails, show the error and stop.
+
+After success, extract the new version and tag from the output.
+
+## Step 4: Monitor the release workflow
+
+Poll the GitHub Actions release workflow until it completes (10-minute timeout):
+
+```bash
+# Check every 15 seconds
+gh run list --workflow=release.yml --limit=1 --json status,conclusion,databaseId,url --jq '.[0]'
+```
+
+While polling, show the user:
+- Current status (queued, in_progress, completed)
+- Elapsed time
+- Individual job statuses when available:
+  ```bash
+  gh run view <run-id> --json jobs --jq '.jobs[] | "\(.name): \(.status) \(.conclusion // "")"'
+  ```
+
+**If the workflow fails**, show the failure URL and stop.
+
+## Step 5: Report results
+
+On success, print a summary:
+
+```
+Release v<version> shipped successfully.
+
+- GitHub Release: https://github.com/<owner>/<repo>/releases/tag/v<version>
+- Workflow run:   <workflow-url>
+
+To upgrade locally:
+  brew update && brew upgrade sipag
+```

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: review
+description: Run a multi-perspective review on a pull request — security, architecture, correctness.
+---
+
+Run a multi-perspective review on a pull request.
+
+## Step 1: Fetch the PR diff
+
+```bash
+gh pr diff <PR-number> --repo <owner/repo>
+```
+
+Also fetch the PR description for context:
+
+```bash
+gh pr view <PR-number> --repo <owner/repo> --json title,body
+```
+
+## Step 2: Launch 4 review agents in parallel
+
+Send a **single message** with 4 Task tool calls so they run concurrently. Each agent receives:
+
+```
+You are reviewing PR #<N> in <owner/repo>.
+
+<pr-description>
+<the PR title and body>
+</pr-description>
+
+<diff>
+<the full diff output>
+</diff>
+```
+
+The 4 agents:
+
+1. **Security reviewer** (`security-reviewer` agent) — Scan the diff for: secrets or tokens, injection risks (SQL, command, path traversal), unsafe deserialization, hardcoded credentials, new dependencies with known CVEs, permission/auth changes. Only flag issues actually present in the diff.
+
+2. **Architecture reviewer** (`architecture-reviewer` agent) — Evaluate the diff for: module boundary violations, increased coupling between components, broken abstraction layers, API surface changes without migration path, pattern breaks vs. established conventions.
+
+3. **Correctness reviewer** (`correctness-reviewer` agent) — Check: logic errors, off-by-one bugs, unhandled error cases, race conditions, null/None handling, integer overflow, resource leaks, incorrect state transitions.
+
+4. **Test adequacy reviewer** — Check: new code has corresponding tests, changed behavior has updated tests, edge cases are covered, test assertions are meaningful (not just "it doesn't crash"), integration paths are tested.
+
+Each agent must end its response with exactly one verdict line:
+
+```
+VERDICT: APPROVE
+VERDICT: APPROVE_WITH_NOTES
+VERDICT: REQUEST_CHANGES
+```
+
+## Step 3: Synthesize verdicts
+
+Combine all 4 agent responses into a single review summary:
+
+```
+## Review Summary for PR #<N>
+
+### Security
+<verdict> — <key findings or "No issues">
+
+### Architecture
+<verdict> — <key findings or "No issues">
+
+### Correctness
+<verdict> — <key findings or "No issues">
+
+### Test Adequacy
+<verdict> — <key findings or "No issues">
+
+### Overall
+<APPROVE / APPROVE_WITH_NOTES / REQUEST_CHANGES>
+<1-2 sentence summary>
+```
+
+## Step 4: Post as PR comment
+
+```bash
+gh pr comment <PR-number> --repo <owner/repo> --body "<the review summary>"
+```

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ship-it
+description: Commit, push, create a PR, run review agents, fix issues, and merge.
+---
+
+Commit, push, create a PR, run review agents, fix issues, and merge.
+
+## Step 1: Prepare the branch
+
+Check the current git state:
+
+```bash
+git status
+git branch --show-current
+```
+
+**If on main/master:**
+1. Create a feature branch from the changes:
+   ```bash
+   git checkout -b <descriptive-branch-name>
+   ```
+2. Stage and commit all changes with a clear commit message.
+
+**If on a feature branch:**
+1. Stage and commit any uncommitted changes.
+2. If there are no uncommitted changes, continue to Step 2.
+
+## Step 2: Push and create (or update) the PR
+
+```bash
+git push -u origin <branch-name>
+```
+
+Check if a PR already exists for this branch:
+
+```bash
+gh pr view <branch-name> --json number,url 2>/dev/null
+```
+
+**If no PR exists**, create one:
+
+```bash
+gh pr create --title "<concise title>" --body "## Summary
+
+<1-3 bullet points describing the changes>
+
+## Test plan
+
+- [ ] <how to verify the changes work>
+"
+```
+
+**If a PR already exists**, note its number and continue.
+
+## Step 3: Review-fix loop
+
+Repeat until all agents approve:
+
+### 3a. Gather the diff
+
+```bash
+gh pr diff <PR-number>
+```
+
+### 3b. Launch review agents in parallel
+
+Send a **single message** with Task tool calls so they run concurrently. Each agent receives the PR description and full diff.
+
+Launch at minimum:
+
+1. **Security reviewer** (`security-reviewer` agent) — Scan for injection risks, credential leaks, dependency issues, auth changes.
+2. **Correctness reviewer** (`correctness-reviewer` agent) — Check for logic errors, unhandled cases, race conditions, resource leaks.
+3. **Code quality reviewer** — Evaluate naming, structure, test coverage, and adherence to project conventions.
+
+Also launch any project-specific review agents that exist in `.claude/agents/`.
+
+Each agent must end with a verdict:
+
+```
+VERDICT: APPROVE
+VERDICT: APPROVE_WITH_NOTES
+VERDICT: REQUEST_CHANGES
+```
+
+### 3c. Compile and post the review
+
+Combine agent responses into a review summary and post it:
+
+```bash
+gh pr comment <PR-number> --body "<review summary>"
+```
+
+### 3d. Fix any issues
+
+If any agent returned `REQUEST_CHANGES`:
+1. Fix the issues they identified.
+2. Commit and push the fixes.
+3. Return to step 3a.
+
+If all agents returned `APPROVE` or `APPROVE_WITH_NOTES`, continue to Step 4.
+
+## Step 4: Merge
+
+```bash
+gh pr merge <PR-number> --squash --delete-branch
+```
+
+Print the merged PR URL.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: triage
+description: Deep triage — trace open issues to root causes, find eliminations, and propose structural PRs.
+---
+
+Deep triage: trace open issues to root causes, find eliminations, and propose structural PRs.
+
+## Step 1: Identify the repository
+
+Resolve `owner/repo` from the git remote of the current working directory:
+
+```bash
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+Store this as `REPO` for subsequent commands.
+
+## Step 2: Fetch issues and project docs
+
+Fetch all open issues for context:
+
+```bash
+gh issue list --repo <REPO> --state open --json number,title,labels,assignees,createdAt,updatedAt --limit 200
+```
+
+Count the total and note how many carry the `ready` label.
+
+Also read project docs (CLAUDE.md, README.md) from the local working directory to ground the synthesis phase.
+
+## Step 3: Launch 3 agents in parallel
+
+Send a **single message** with 3 Task tool calls so they run concurrently:
+
+1. **root-cause-analyst** (`root-cause-analyst` agent) — Pass it:
+   ```
+   Analyze all open issues for <REPO>. Follow your full procedure: fetch project docs, fetch all open issues with bodies, trace issues to code, identify root causes using engineering principles, rank them, and prescribe structural cures. Focus on finding the disease, not the symptoms.
+   ```
+
+2. **simplicity-advocate** (`simplicity-advocate` agent) — Pass it:
+   ```
+   Analyze all open issues for <REPO>. Follow your full procedure: fetch project docs, fetch open and recently closed issues, read the implicated code, apply elimination tests and smallest-fix tests, check for wrong-question issues, identify essential complexity, and recommend simplifications.
+   ```
+
+3. **issue-analyst** (`issue-analyst` agent) — Pass it:
+   ```
+   Analyze all open issues for <REPO>. Follow your full procedure: fetch issues, cluster by theme, evaluate from 3 perspectives, and recommend the highest-impact next PR. Focus on issues labeled `ready`.
+   ```
+
+Wait for all three agents to complete before proceeding.
+
+## Step 4: Synthesize across perspectives
+
+Combine the three agent outputs into a unified analysis. This is the most important step — the agents provide raw perspectives, you provide the judgment.
+
+### 4a: Build the root-cause map
+
+Start with root-cause-analyst's findings. For each root cause, note:
+- Which issues it explains
+- What code it implicates
+- What cure it proposes
+
+### 4b: Resolve disagreements
+
+When the agents disagree, apply these heuristics:
+
+- **Root-cause-analyst proposes adding an abstraction AND simplicity-advocate proposes eliminating** →
+  - If the abstraction would have only one consumer: simplicity-advocate wins
+  - If elimination would create duplication: root-cause-analyst wins
+  - Tie-break: fewer net lines wins
+
+- **Issue-analyst's clusters cut across root causes** →
+  - Prefer root-cause grouping (structurally coherent PRs over thematically grouped PRs)
+  - Exception: if a root-cause PR would touch 10+ files, split along issue-analyst cluster lines
+
+- **Simplicity-advocate says "do nothing" AND others propose changes** →
+  - If the issue is a feature request with low demand: simplicity-advocate wins
+  - If the issue reports actual breakage: proceed with the change
+
+Note every disagreement and how you resolved it. Transparency builds trust.
+
+### 4c: Scope to PR-sized chunks
+
+Apply these scoping rules to each proposed change:
+
+- Each PR addresses **one root cause or one simplification** — not a mix
+- Max **5 issues per PR**, prefer 2-3
+- Every file modified serves the **same structural goal**
+- If a cure touches **10+ files**, split into sequential PRs with clear ordering
+- PRs that **delete code rank higher** than PRs that add code
+
+### 4d: Write PR specifications
+
+Each PR body is the **complete briefing** for an isolated Docker worker that has no access to this conversation. The worker reads the PR description verbatim via `gh pr view` — it is everything they know. Write accordingly: a senior engineer reading only the PR body should understand the disease, the cure, and why this cure over alternatives.
+
+For each proposed PR, write a full specification following this structure:
+
+```
+### PR: <title — imperative, under 70 chars>
+**Priority**: <rank among proposed PRs>
+**Dependencies**: <which PRs must land first, if any>
+```
+
+Then write the PR body that will be used in `gh pr create --body`:
+
+```markdown
+## The disease
+
+<What structural flaw exists in the codebase and WHY it exists. Not "X is broken" but "X was designed for Y context, but the codebase has since evolved to Z context, creating a mismatch that manifests as..." Explain the history — when was this code written, what tradeoff was it making, why was that tradeoff reasonable at the time, and what changed.>
+
+## Symptoms (open issues)
+
+<For each issue this PR addresses, quote the relevant parts of the issue body and explain how each symptom traces back to the disease above. The worker should see the causal chain from structural flaw → each bug.>
+
+- **Closes #X — <title>**: <How this issue is a symptom of the disease. Quote specific details from the issue body.>
+- **Closes #Y — <title>**: <Same.>
+- **Partially addresses #Z — <title>**: <What gets fixed and what remains.>
+
+## Code evidence
+
+<For EVERY file the worker will need to modify, include:>
+
+- `<file:line>` — <What this code does now, what's wrong with it structurally, and what it should become. Include enough surrounding context (function signatures, data flow) that the worker can navigate directly to the right place without exploring.>
+
+<Also include files the worker should READ but not modify, to understand the broader context:>
+
+- `<file:line>` (read-only context) — <Why the worker needs to understand this code to make the right changes.>
+
+## The cure
+
+<The structural change at the design level. Not "edit file X" but "introduce concept Y that replaces the current pattern of Z". Explain the design PRINCIPLE being applied — e.g., "This follows the principle of making illegal states unrepresentable" or "This eliminates accidental coupling by giving each module a single reason to change.">
+
+### Implementation steps
+
+<Numbered, specific steps. Each step should name the file, the function, and what changes. Include code sketches for non-obvious transformations — the worker should not have to guess what the target state looks like.>
+
+1. <Step — specific enough that the worker knows exactly what to do>
+2. <Step>
+3. <Step>
+
+### What the code looks like after
+
+<Describe the target architecture in 2-3 sentences. What concepts exist, how do they relate, what's the data flow? This is the "after" picture that helps the worker evaluate their own changes.>
+
+## Design context the worker should know
+
+<The "Rich Hickey" section. Broader architectural observations that are not obvious from the diff but matter for making good decisions:>
+
+- <Why the current abstraction boundaries exist and which ones this PR respects vs. changes>
+- <What essential complexity exists nearby that should NOT be simplified (from simplicity-advocate)>
+- <How this change interacts with the rest of the system — second-order effects>
+- <What the agents disagreed about and how it was resolved, if relevant to this PR>
+- <Any Chesterton's Fence observations — things that look wrong but are load-bearing>
+
+## What NOT to do
+
+<Explicit guardrails. These prevent the worker from over-engineering or going off-scope:>
+
+- Do not <specific anti-pattern the worker might be tempted by>
+- Do not <scope creep risk>
+- <Any "this looks related but is actually a separate concern" warnings>
+
+## Tests
+
+<What tests to add, modify, or remove. Be specific about test scenarios:>
+
+- <Test scenario 1 — what behavior to verify>
+- <Test scenario 2>
+- <Any existing tests that will break and need updating>
+
+## Net lines: <estimate — negative preferred>
+```
+
+## Step 5: Present the triage report
+
+Output the full synthesized report:
+
+```
+## Deep Triage Report for <REPO>
+
+### Root causes identified
+<From root-cause-analyst, validated against code evidence>
+
+### Simplifications found
+<From simplicity-advocate, including essential complexity acknowledgments>
+
+### Issue clusters
+<From issue-analyst, noting where clusters align with or diverge from root causes>
+
+### Disagreements and resolutions
+<Where agents disagreed and how you resolved it>
+
+### Proposed PRs (ranked)
+<PR specifications from Step 4d, ordered by priority>
+
+### Summary
+- Total open issues: N
+- Issues addressed by proposed PRs: N
+- Proposed PRs: N (N delete code, N restructure, N add code)
+- Issues not addressed: N (explain why — isolated bugs, low priority, or need more info)
+```
+
+## Step 6: Ask before creating
+
+Present the ranked PR list and ask the user which PRs to create. Offer options:
+
+1. **Create all** — Create branches and draft PRs for all proposed changes
+2. **Pick specific PRs** — Let the user select which ones to create
+3. **Just the report** — Save the analysis without creating any PRs
+4. **Dispatch immediately** — Create PRs and launch `sipag dispatch` for each
+
+Do not create any PRs without explicit user approval.
+
+## Step 7: Create PRs (if approved)
+
+**Critical**: The PR body is the worker's ONLY context. The worker runs in an isolated Docker container with no access to this conversation, the triage report, or the agent analyses. Everything the worker needs to make good decisions — the disease, the code evidence, the design rationale, the guardrails — must be in the PR body. Write as if briefing a senior engineer who is joining the project today.
+
+For each approved PR:
+
+1. Create a branch from main with an empty commit (GitHub requires at least one commit to create a PR):
+   ```bash
+   git checkout -b sipag/triage-<short-name> main
+   git commit --allow-empty -m "chore: <short description of structural fix>"
+   git push -u origin sipag/triage-<short-name>
+   git checkout main
+   ```
+
+2. Create a draft PR using the full specification from Step 4d as the body. Use a heredoc to preserve formatting:
+   ```bash
+   gh pr create --repo <REPO> --base main --head sipag/triage-<short-name> \
+     --title "<PR title>" --body "$(cat <<'BODY'
+   <Full PR body from Step 4d — disease, symptoms, code evidence, cure, design context, guardrails, tests>
+   BODY
+   )" --draft
+   ```
+
+3. If the user chose "Dispatch immediately", run:
+   ```bash
+   sipag dispatch <PR_URL>
+   ```
+
+Report the created PR URLs back to the user.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: work
+description: Dispatch multiple PRs to isolated Docker workers in parallel, respecting back-pressure limits.
+---
+
+Dispatch multiple PRs to isolated Docker workers in parallel, respecting back-pressure limits.
+
+## Overview
+
+The `/work` command is the batch dispatcher. After `/triage` creates draft PRs, `/work` sends them all to Docker workers — launching as many as the back-pressure limit allows, then waiting and backfilling as workers finish.
+
+`$ARGUMENTS` is optional. It can be:
+- Empty → auto-discover draft PRs labeled `sipag`
+- A list of PR URLs or numbers → dispatch exactly those
+- `all` → dispatch all open draft PRs regardless of label
+
+## Step 1: Identify the repository
+
+```bash
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+Store as `REPO`.
+
+## Step 2: Determine the work queue
+
+### If `$ARGUMENTS` contains PR URLs or numbers
+
+Parse them into a list. PR URLs look like `https://github.com/owner/repo/pull/N`. Bare numbers like `496 497 498` are also valid — expand them to full URLs using `REPO`.
+
+### If `$ARGUMENTS` is empty or `all`
+
+Discover draft PRs to dispatch:
+
+```bash
+gh pr list --repo <REPO> --state open --draft --json number,title,url,headRefName,labels,isDraft --limit 50
+```
+
+**Default (no arguments):** Filter to PRs with the `sipag` label. These are PRs created by `/triage` or `/dispatch` that are ready for workers.
+
+**`all`:** Use all open draft PRs.
+
+Sort by PR number (ascending) so earlier PRs land first.
+
+## Step 3: Pre-flight checks
+
+Before dispatching anything, verify the system is ready:
+
+```bash
+# Check sipag is available
+which sipag
+
+# Check Docker daemon
+docker info > /dev/null 2>&1
+
+# Check current worker status
+sipag ps
+```
+
+Read the back-pressure limit from `~/.sipag/config` (key: `max_open_prs`, default: `3`). A value of `0` means back-pressure is disabled — all PRs can dispatch immediately.
+
+Count active workers from `sipag ps` output. Active workers have phase `starting` or `working` (not `finished` or `failed`).
+
+Report the queue:
+
+```
+## Work queue
+
+Found N draft PRs to dispatch:
+- #496: Dockerfile hardening
+- #497: TUI detail view live refresh
+
+Back-pressure limit: K concurrent workers (0 = unlimited)
+Currently active: M workers
+Available slots: S
+```
+
+If there are no PRs to dispatch, stop and tell the user.
+
+## Step 4: Dispatch with back-pressure
+
+This is the core loop. The goal: keep worker slots full until all PRs are dispatched.
+
+### Algorithm
+
+```
+queue = list of PR URLs to dispatch (from Step 2)
+dispatched = []
+failed = []
+
+while queue is not empty:
+    1. Check active worker count:
+       Run `sipag ps` and count workers with phase "starting" or "working".
+
+    2. Calculate available slots:
+       if max_open_prs == 0:
+           slots = len(queue)        # back-pressure disabled — dispatch all
+       else:
+           slots = max_open_prs - active_count
+
+    3. If slots > 0:
+       Take up to `slots` PRs from the front of queue.
+       For each PR, dispatch sequentially with an enforced 2-second pause:
+
+           sipag dispatch <PR_URL>
+           sleep 2
+
+       - If dispatch succeeds (exit code 0): add to dispatched list
+       - If dispatch fails (non-zero exit): add to failed list with stderr reason
+         Continue with remaining PRs.
+
+    4. If slots == 0 and queue still has items:
+       Wait 30 seconds, then loop back to step 1.
+       Print: "Waiting for slots... (N dispatched, M queued, F failed)"
+
+    5. After 5 consecutive waits with no change in active worker count,
+       warn the user and ask whether to continue waiting or abort.
+```
+
+### Executing dispatches
+
+For each PR in the batch:
+
+```bash
+sipag dispatch "https://github.com/<REPO>/pull/<N>" 2>&1
+sleep 2
+```
+
+Capture both stdout/stderr and exit code. A non-zero exit code means dispatch failed — record the error but continue with remaining PRs.
+
+**Important:** Run each `sipag dispatch` call sequentially (not `&` backgrounded) because:
+1. Each dispatch call does its own back-pressure check
+2. Concurrent dispatches race on the worker count and may overshoot
+3. The enforced `sleep 2` between calls prevents GitHub API rate limiting
+
+**Safety:** PR titles and metadata from `gh pr list` are untrusted user input. When displaying PR information in output, never interpolate titles directly into shell commands. Use them only in markdown output text, not in bash command arguments.
+
+## Step 5: Monitor until completion
+
+After all PRs are dispatched (or the queue is exhausted due to failures), monitor worker progress:
+
+```
+## Dispatch complete
+
+Dispatched: N PRs
+Failed to dispatch: M PRs
+```
+
+If any failed, list them with reasons:
+
+```
+### Failed dispatches
+- #496: Back-pressure limit reached (should not happen with wait loop — investigate)
+- #499: PR already has an active worker
+```
+
+Then tell the user how to monitor:
+
+```
+### Monitor progress
+
+Watch all workers:
+  sipag tui
+
+Check status:
+  sipag ps
+
+View logs for a specific worker:
+  sipag logs <PR-number>
+```
+
+## Step 6: Wait for results (optional)
+
+Ask the user whether they want to:
+
+1. **Monitor here** — Poll `sipag ps` every 60 seconds and report when workers finish, showing a summary table
+2. **Use TUI** — Suggest `sipag tui` for the live dashboard
+3. **Done** — Exit, workers continue in background
+
+If the user chooses "Monitor here", poll and report:
+
+```
+## Worker status (updated every 60s)
+
+| PR | Title | Status | Duration |
+|----|-------|--------|----------|
+| #496 | Dockerfile hardening | working | 4m 32s |
+| #497 | TUI detail view | working | 4m 15s |
+| #498 | TUI test soundness | working | 4m 01s |
+| #499 | OnceLock timeout | queued | — |
+| #500 | chrono workspace | queued | — |
+
+Active: 3 | Finished: 0 | Failed: 0 | Queued: 2
+```
+
+When a worker finishes (phase changes to `finished` or `failed`):
+- Report it immediately
+- If the worker failed, show the last 10 lines of its log
+- If there are queued PRs waiting, dispatch the next one
+
+When all workers are done, print the final summary:
+
+```
+## Final results
+
+| PR | Title | Result | Duration | Link |
+|----|-------|--------|----------|------|
+| #496 | Dockerfile hardening | finished | 12m 45s | https://github.com/owner/repo/pull/496 |
+| #497 | TUI detail view | finished | 18m 02s | https://github.com/owner/repo/pull/497 |
+| #498 | TUI test soundness | failed | 8m 11s | https://github.com/owner/repo/pull/498 |
+| #499 | OnceLock timeout | finished | 5m 33s | https://github.com/owner/repo/pull/499 |
+| #500 | chrono workspace | finished | 3m 12s | https://github.com/owner/repo/pull/500 |
+
+Finished: 4 | Failed: 1
+
+Failed workers — check logs:
+  sipag logs 498
+```
+
+## Safety
+
+- **Never log or print credential values.** The `sipag dispatch` command passes tokens via environment variables internally. Do not echo, log, or display `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, or `GH_TOKEN` values. Only show the PR URL being dispatched and the exit status.
+- **PR titles are untrusted.** When showing PR information in status tables or output, use them as plain text in markdown — never interpolate them into shell command strings.
+
+## Error handling
+
+- **`sipag` not found**: Tell the user to install sipag or check their PATH.
+- **Docker not running**: Tell the user to start Docker Desktop.
+- **Auth failure**: Tell the user to run `gh auth login` and verify that their Anthropic credentials are configured in the environment. Do not print or echo token values.
+- **All dispatches fail**: Stop early, report the common error, suggest `sipag doctor`.
+- **Rate limiting**: If GitHub API returns 403, back off for 60 seconds before retrying.


### PR DESCRIPTION
## Summary

Adds hulma v0.2.1's reference templates as a baseline `.claude/` surface:
- `.claude/skills/{consult,dispatch,release,review,ship-it,triage,work}/SKILL.md`
- New review-agent templates in `.claude/agents/` (pre-existing customized agents preserved)
- `.claude/hooks/katulong-pubsub.sh`
- `.husky/{pre-commit,pre-push}`

Generated by `hulma configure --static` from main.

## Activation

```
git config core.hooksPath .husky
```